### PR TITLE
default.pa for Samsung Chromebook Plus

### DIFF
--- a/Samsung_Chromebook_Plus.md
+++ b/Samsung_Chromebook_Plus.md
@@ -11,3 +11,17 @@ ALSA_CONFIG_UCM=/opt/alsa/ucm alsaucm -c rk3399-gru-sound set _verb HiFi
 ```
 
 Note that the port will display as "Headphones" despite using the speakers.  When paired with pulseaudio and pulseaudio-alsa, be aware that the full volume range is addressed through levels 0-9 of the Master volume control.  Levels 10-100 provide no additional gain.
+
+If using pulseaudio, the following can be placed in your `~/.config/pulse/default.pa` file to create a loopback device that fixes the volume levels, so that 0-100% in a desktop environment's volume bar will correspond to the audio level heard in the spaker.
+
+```
+.include /etc/pulse/default.pa
+  
+load-module module-null-sink sink_name=corrected_speakers sink_properties=device.description=corrected_speakers
+
+load-module module-loopback source=corrected_speakers.monitor sink=alsa_output.platform-sound.stereo-fallback remix=false
+
+set-sink-volume alsa_output.platform-sound.stereo-fallback 6553
+
+set-default-sink corrected_speakers
+```


### PR DESCRIPTION
Include a default.pa file which corrects the volume level for the Samsung Chromebook Plus so that volume hotkeys and volume sliders in the desktop environment behave correctly over 0-100%.